### PR TITLE
Configuracion de GIT para enviar archivos de gran tamaño

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.csv filter=lfs diff=lfs merge=lfs -text
+*.json filter=lfs diff=lfs merge=lfs -text

--- a/EDA.ipynb
+++ b/EDA.ipynb
@@ -1,0 +1,19 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/ETL.ipynb
+++ b/ETL.ipynb
@@ -1,0 +1,19 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/datasets/originals/1.json
+++ b/datasets/originals/1.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ba85b5f1c85075f308281558f3b88e0af528041c0d13880b24160ef9dfdbe80
+size 256143794

--- a/datasets/originals/10.json
+++ b/datasets/originals/10.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ad21c76109ed917c9c631d023f496f29c9f9e9900719992979bdd3e8176b804
+size 281893034

--- a/datasets/originals/11.json
+++ b/datasets/originals/11.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8da0fd1d790abe6232f5e5b2024e2501e77d9813e8c1390a4ec3c11a110a4dda
+size 287516373

--- a/datasets/originals/2.json
+++ b/datasets/originals/2.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:144aa42b72bb7557732690aab507858d6d9701f6acee4b4f50193d1a4d7e5a19
+size 257465654

--- a/datasets/originals/3.json
+++ b/datasets/originals/3.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4f68605b1952c7d336ef4fe13728613012082a379d1256311e79246c19fb14e
+size 259327260

--- a/datasets/originals/4.json
+++ b/datasets/originals/4.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24dba1d7965c24354d9e866e00537099983f19548dc577a2abcf0174d816e37e
+size 262091279

--- a/datasets/originals/5.json
+++ b/datasets/originals/5.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a744dcf037ce48d9125eaf7b4921acb95e58edd0d2f20ed663eb8c6c7018b541
+size 264306323

--- a/datasets/originals/6.json
+++ b/datasets/originals/6.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:251ef193e1226cb1856fb64c83b23e77345349a009b6ddb738fcc0808df027ac
+size 267040091

--- a/datasets/originals/7.json
+++ b/datasets/originals/7.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65a64e48b0a2ad19a6eb7f3954c1fec27475d2428a07ba22bd31540038159610
+size 272906909

--- a/datasets/originals/8.json
+++ b/datasets/originals/8.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:072a3780609cf1039ff4f4da7b666d96e72b096779afdb7c8ad2ce97f46cb162
+size 284212855

--- a/datasets/originals/9.json
+++ b/datasets/originals/9.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:601d737dac74db952b959f40c1c6d216b01a3d5d17201b90554fb3598f2fdeff
+size 277001086


### PR DESCRIPTION
Con esta configuracion podemos enviar los archivos de mas de 200mb al repositorio.